### PR TITLE
Added option for writing raster datatype of splitRaster

### DIFF
--- a/man/SpaDES.tools-package.Rd
+++ b/man/SpaDES.tools-package.Rd
@@ -117,7 +117,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Alex M Chubaty \email{alexander.chubaty@canada.ca}
+\strong{Maintainer}: Alex M Chubaty \email{alex.chubaty@gmail.com}
 
 Authors:
 \itemize{

--- a/man/splitRaster.Rd
+++ b/man/splitRaster.Rd
@@ -13,10 +13,10 @@ mergeRaster(x)
 \S4method{mergeRaster}{list}(x)
 
 splitRaster(r, nx = 1, ny = 1, buffer = c(0, 0),
-  path = file.path(getwd(), names(r)), cl)
+  path = file.path(getwd(), names(r)), cl, rType = "FLT4S")
 
 \S4method{splitRaster}{RasterLayer}(r, nx = 1, ny = 1, buffer = c(0, 0),
-  path = file.path(getwd(), names(r)), cl)
+  path = file.path(getwd(), names(r)), cl, rType = "FLT4S")
 }
 \arguments{
 \item{x}{A list of split raster tiles (i.e., from \code{splitRaster}).}
@@ -42,6 +42,8 @@ working directory based on the raster's name (i.e., using \code{names(x)}).}
 parallel::makeCluster or equivalent. This is an alternative way, instead
 of \code{beginCluster()}, to use parallelism for this function, allowing for
 more control over cluster use.}
+
+\item{rType}{Datatype of the split rasters. Defaults to FLT4S.}
 }
 \value{
 \code{mergeRaster} returns a \code{RasterLayer} object.

--- a/tests/testthat/test-splitRaster.R
+++ b/tests/testthat/test-splitRaster.R
@@ -3,7 +3,7 @@ test_that("splitRaster and mergeRaster work on small in-memory rasters", {
   library(raster); on.exit(detach("package:raster"), add = TRUE)
 
   owd <- getwd()
-  tmpdir <- file.path(tempdir(), "splitRaster-test") %>% checkPath(create = TRUE)
+  tmpdir <- file.path(tempdir(), "splitRaster-test") %>% reproducible::checkPath(create = TRUE)
   setwd(tmpdir)
 
   on.exit({
@@ -135,6 +135,13 @@ test_that("splitRaster and mergeRaster work on small in-memory rasters", {
     }
     rowmaxtemp <- rowmax
   }
+  #compatible with different raster datatypes
+  y4 <- splitRaster(r, nx, ny, rType = "INT1U")
+  expect_identical(dataType(y4[[1]]),"INT1U")
+  #defaults to FLT4S
+  expect_warning(y5 <- splitRaster(r, nx, ny, rType = "INT"))
+  y5 <- splitRaster(r, nx, ny)
+  expect_true(dataType(y5[[1]]) == "FLT4S")
 })
 
 test_that("splitRaster works in parallel", {
@@ -145,7 +152,7 @@ test_that("splitRaster works in parallel", {
   if (interactive()) {
     library(raster); on.exit(detach("package:raster"), add = TRUE)
 
-    tmpdir <- file.path(tempdir(), "splitRaster-test-parallel") %>% checkPath(create = TRUE)
+    tmpdir <- file.path(tempdir(), "splitRaster-test-parallel") %>% reproducible::checkPath(create = TRUE)
 
     on.exit({
       #detach("package:raster")
@@ -206,7 +213,7 @@ test_that("splitRaster and mergeRaster work on large on-disk rasters", {
   skip_on_appveyor()
   skip("This is very big.")
 
-  tmpdir <- file.path(tempdir(), "splitRaster-test-large") %>% checkPath(create = TRUE)
+  tmpdir <- file.path(tempdir(), "splitRaster-test-large") %>% reproducible::checkPath(create = TRUE)
   library(magrittr)
   library(raster); on.exit(detach("package:raster"), add = TRUE)
 


### PR DESCRIPTION
Seems like if a raster is big enough that it needs to be split, it might also need to be in a format other than FLT4S