### PR TITLE
changes to downloadData: avoiding SpaDES.core functions

### DIFF
--- a/R/downloadData.R
+++ b/R/downloadData.R
@@ -365,7 +365,6 @@ remoteFileSize <- function(url) {
 #' @importFrom reproducible checkPath compareNA
 #' @importFrom httr http_error
 #' @importFrom utils download.file
-#' @importFrom SpaDES.core moduleMetadata .parseModulePartial
 #' @rdname downloadData
 #' @examples
 #' \dontrun{

--- a/tests/testthat/test-downloadData.R
+++ b/tests/testthat/test-downloadData.R
@@ -72,15 +72,61 @@ test_that("downloadData downloads and unzips module data", {
     }
 
     # downloads data using urls described in module metadata
-    library(SpaDES.core); on.exit(detach("package:SpaDES.core"), add = TRUE)
     m <- "LccToBeaconsReclassify"
-    tmpdir <- file.path(tempdir(), "modules") %>% checkPath(create = TRUE)
-    dataDir <- file.path(tmpdir, m, "data")
+    tmpdir <- file.path(tempdir(), "modules") %>% reproducible::checkPath(create = TRUE)
+    dataDir <- file.path(tmpdir, m, "data") %>% reproducible::checkPath(create = TRUE)
+
+    ## write the defineModude function into an .Rscript to circumvent using downloadmodule
+    writeLines(con = file.path(tmpdir, m, paste0(m, ".R")),
+               text = "defineModule(sim, list(
+                 name = \"LccToBeaconsReclassify\",
+                 description = \"Takes the LCC05 classification of 39 land cover classes, and reclassifies it to the 11 classes of the Beacons succession model.\",
+                 keywords = c(\"forest succession\", \"LCC05\", \"land cover classification 2005\", \"Beacons\"),
+                 childModules = character(),
+                 authors = c(
+                   person(c(\"Eliot\", \"J\", \"B\"), \"McIntire\", email = \"eliot.mcintire@canada.ca\", role = c(\"aut\", \"cre\")),
+                   person(c(\"Alex\", \"M\"), \"Chubaty\", email = \"alexander.chubaty@canada.ca\", role = c(\"aut\")),
+                   person(\"Steve\", \"Cumming\", email = \"Steve.Cumming@sbf.ulaval.ca\", role = c(\"aut\"))
+                 ),
+                 version = numeric_version(\"1.1.2\"),
+                 spatialExtent = raster::extent(rep(NA_real_, 4)),
+                 timeframe = as.POSIXlt(c(\"2005-01-01\", NA)),
+                 timeunit = \"year\",
+                 citation = list(\"citation.bib\"),
+                 documentation = list(\"README.txt\", \"LccToBeaconsReclassify.Rmd\"),
+                 reqdPkgs = list(\"raster\", \"RColorBrewer\", \"fastmatch\", \"dplyr\"),
+                 parameters = rbind(
+                   defineParameter(\".plotInitialTime\", \"numeric\", NA_real_, NA, NA, desc = \"Initial time for plotting\"),
+                   defineParameter(\".plotInterval\", \"numeric\", NA_real_, NA, NA, desc = \"Interval between plotting\"),
+                   defineParameter(\".saveInitialTime\", \"numeric\", NA_real_, NA, NA, desc = \"Initial time for saving\"),
+                   defineParameter(\".saveInterval\", \"numeric\", NA_real_, NA, NA, desc = \"Interval between save events\")
+                 ),
+                 inputObjects = data.frame(
+                   objectName = \"vegMapLcc\", objectClass = \"RasterLayer\",
+                   sourceURL = \"ftp://ftp.ccrs.nrcan.gc.ca/ad/NLCCLandCover/LandcoverCanada2005_250m/LandCoverOfCanada2005_V1_4.zip\",
+                   other = NA_character_, stringsAsFactors = FALSE),
+                 outputObjects = data.frame(
+                   objectName = c(\"trajMapBeacons\", \"vegMapBeacons\", \"trajObj\"),
+                   objectClass = c(\"RasterLayer\", \"RasterLayer\", \"matrix\"),
+                   other = rep(NA_character_, 3L), stringsAsFactors = FALSE)
+               ))")
+
+    ## write associated CHECKSUMS.txt
+    chksums <- structure(list(
+      file = structure(1:2, .Label = c("LCC2005_V1_4a.tif", "LandCoverOfCanada2005_V1_4.zip"),
+                       class = "factor"),
+      checksum = structure(1:2, .Label = c("b50567fc83bcc5de" , "e100c037a257e377"),
+                           class = "factor"),
+      filesize = structure(1:2, .Label = c("437916202", "47185238"), class = "factor"),
+      algorithm = structure(1:2, .Label = c("xxhash64", "xxhash64"), class = "factor")),
+      .Names = c("file", "checksum", "filesize", "algorithm"),
+      class = "data.frame", row.names = c(NA, -2L))
+
+    write.table(chksums, file = file.path(dataDir, "CHECKSUMS.txt"), row.names = FALSE)
 
     filenames <- c("LandCoverOfCanada2005_V1_4.zip")
 
     on.exit(unlink(tmpdir, recursive = TRUE), add = TRUE)
-    downloadModule(name = m, path = tmpdir, data = FALSE, quiet = TRUE)
     suppressWarnings(downloadData(module = m, path = tmpdir, quiet = TRUE))
 
     expect_true(all(file.exists(file.path(dataDir, filenames))))


### PR DESCRIPTION
These should be temporary bypasses, as I think they make the code quite convoluted and possibly not very robust to changes in how users define their module metadata